### PR TITLE
use `UCD4IDS` instead of `ucd4ids` in make.jl

### DIFF
--- a/docs/make.jl
+++ b/docs/make.jl
@@ -28,5 +28,5 @@ makedocs(
 # See "Hosting Documentation" and deploydocs() in the Documenter manual
 # for more information.
 deploydocs(
-    repo = "github.com/ucd4ids/MultiscaleGraphSignalTransforms.jl.git"
+    repo = "github.com/UCD4IDS/MultiscaleGraphSignalTransforms.jl.git"
 )


### PR DESCRIPTION
Currently, the documentation is not deployed properly by `make.jl`. I think it is probably caused by the wrong username I provided.