### PR TITLE
Complete the 1D case of `GraphSig_Plot()` and add `:propabs` option in `scatter_gplot()`

### DIFF
--- a/src/GraphSig_Plot.jl
+++ b/src/GraphSig_Plot.jl
@@ -81,55 +81,43 @@ function GraphSig_Plot(G::GraphSig; symmetric::Bool = false,
     if G.dim == 1
         if G.length < 65 || stemplot
             # stem(G.xy, G.f, '-o','LineWidth',2,'Color',linecolor,'MarkerFaceColor',linecolor,'MarkerSize',markersize(1));
-            stem(G.xy, G.f, linetype = [:sticks :scatter], linewidth = 2, linecolor = linecolor, markercolor = linecolor, markersize = markersize)
-            # plot(1:G.length , G.f, line = :sticks)
-            # plot!(1:G.length , G.f, line = :scatter)
+            # stem(G.xy, G.f, linetype = [:sticks :scatter], linewidth = 2, linecolor = linecolor, markercolor = linecolor, markersize = markersize)
+            stem(G.f; x = G.xy, lw = linewidth, c = linecolor, ms = markersize, shape = markershape)
         else
             # plot(G.xy, G.f, '-','Color',linecolor,'LineWidth',linewidth);
             plot(G.xy, G.f, linetype = :line, linecolor = linecolor, linewidth = linewidth);
         end
 
-        xmin = minimum(G.xy);
-        xmax = maximum(G.xy);
-
-        #     dx = xmax-xmin;
-        #     if dx < 10*eps
-        #         dx = 1;
-        #     end
-        #     xmin = xmin - 0.1*dx;
-        #     xmax = xmax + 0.1*dx;
-
-        ymin = minimum(G.f);
-        ymax = maximum(G.f);
-        dy = ymax-ymin;
-        if dy < 10*eps
-            dy = 1;
+        xmin = minimum(G.xy)
+        xmax = maximum(G.xy)
+        dx = xmax - xmin
+        if dx < 10 * eps()
+            dx = 1
         end
-        ymin = ymin - 0.1*dy;
-        ymax = ymax + 0.1*dy;
+        xmin = xmin - 0.1 * dx
+        xmax = xmax + 0.1 * dx
+
+        ymin = minimum(G.f)
+        ymax = maximum(G.f)
+        dy = ymax - ymin
+        if dy < 10 * eps()
+            dy = 1
+        end
+        ymin = ymin - 0.1*dy
+        ymax = ymax + 0.1*dy
 
         # symmetric?
         if symmetric
-            ymax = 1.1*max(ymax, -ymin);
-            ymin = -ymax;
+            ymax = 1.1 * max(ymax, -ymin)
+            ymin = -ymax
         end
 
-        #axis([xmin, xmax, ymin, ymax]);
-        xaxis!(xlim = (xmin, xmax))
-        yaxis!(ylim = (ymin, ymax))
-
-        if clim != (0., 0.)
-            xaxis!(xlim = (xmin, xmax))
-            yaxis!(ylim = clim)
-        else
-            #axis([xmin, xmax, ymin, ymax]);
-            xaxis!(xlim = (xmin, xmax))
-            yaxis!(ylim = (ymin, ymax))
-        end
+        xlims!(xmin, xmax)
+        ylims!(ymin, ymax)
 
         # title?
         if ~isempty(G.name) && ~notitle
-            title!(G.name);
+            title!(G.name)
         end
 
         # legend?

--- a/src/MultiscaleGraphSignalTransforms.jl
+++ b/src/MultiscaleGraphSignalTransforms.jl
@@ -59,7 +59,7 @@ export unitary_folding_operator, keep_folding!
 export ngwp_analysis, ngwp_bestbasis, NGWP_jkl
 export natural_eigdist
 export nat_spec_filter, ngwf_all_vectors, rngwf_all_vectors, ngwf_vector, frame_approx, rngwf_lx
-export scatter_gplot, scatter_gplot!
+export scatter_gplot, scatter_gplot!, stem, stem!
 export standardize_eigenvectors!, spike, characteristic, χ, sort_wavelets, transform2D
 export getall_expansioncoeffs, approx_error_plot, getall_expansioncoeffs2, approx_error_plot2
 

--- a/src/helpers.jl
+++ b/src/helpers.jl
@@ -667,3 +667,43 @@ function approx_error_plot2(DVEC::Vector{Vector{Float64}}; frac::Float64 = 0.50)
                 label = T[i], line = L[i], linewidth = 2, grid = false)
     end
 end
+
+
+"""
+    stem(f; x = 1:length(f[:]), c = :black, ms = 5, shape = :circle, lw = 1)
+Display a length N discrete sequence data in a stem plot.
+
+# Input Arguments
+- `f`: function values could be a vector or an N x 1 matrix.
+- `x`: default is `1:N`. x values.
+- `c::Symbol`: default is `:black`. Color of the markers.
+- `ms::Number`: default is `5`. Size of markers.
+- `shape::Symbol`: default is `:circle`. Shape of the markers.
+- `lw::Number`: default is `1`. The line width of the stems.
+- `subgplot::Int`: default is `1`. The subplot index.
+"""
+function stem(f; x = 1:length(f[:]), c = :black, ms = 5, shape = :circle, lw = 1, subplot = 1)
+    if (ndims(f) == 2 && size(f, 2) > 1) || ndims(f) > 2
+        error("input only accepts a vector or a matrix of size (N, 1).")
+        return
+    end
+    f = f[:]
+    N = length(f)
+    plot(x, f, seriestype = :stem, color = c, lw = lw, subplot = subplot)
+    scatter!(x, f, marker = shape, color = c, ms = ms, mswidth = 0, subplot = subplot)
+    plot!(x, zeros(N), color = :black, lw = lw, subplot = subplot)
+    plot!(grid = false, legend = false, ratio = 1, frame = :none, subplot = subplot)
+end
+
+function stem!(f; x = 1:length(f[:]), c = :black, ms = 5, shape = :circle, lw = 1, subplot = 1)
+    if (ndims(f) == 2 && size(f, 2) > 1) || ndims(f) > 2
+        error("input only accepts a vector or a matrix of size (N, 1).")
+        return
+    end
+    f = f[:]
+    N = length(f)
+    plot!(x, f, seriestype = :stem, color = c, lw = lw, subplot = subplot)
+    scatter!(x, f, marker = shape, color = c, ms = ms, mswidth = 0, subplot = subplot)
+    plot!(x, zeros(N), color = :black, lw = lw, subplot = subplot)
+    plot!(grid = false, legend = false, ratio = 1, frame = :none, subplot = subplot)
+end

--- a/src/helpers.jl
+++ b/src/helpers.jl
@@ -119,7 +119,9 @@ SCATTER\\_GPLOT!(X; ...) adds a plot to `current` one.
 - `mswidth::Number`: default is `0`. Width of the marker stroke border.
 - `msalpha::Number`: default is `nothing`. The opacity for the marker stroke.
 - `plotOrder::Symbol`: default is `:normal`. Optional choices `:s2l` or `:l2s`, i.e.,
-    plots from the smallest value of `marker` to the largest value or the other way around.
+    plots from the smallest value of `marker` to the largest value or the other way around,
+    or `:propabs`, ms is automatically set to be proportional to the absolute value
+    of the marker values.
 - `c::Symbol`: default is `:viridis`. Colors of the markers.
 - `subgplot::Int`: default is `1`. The subplot index.
 
@@ -139,13 +141,21 @@ function scatter_gplot(X; marker = nothing, ms = 4, shape = :none, mswidth = 0,
             idx = sortperm(marker)
         elseif plotOrder == :l2s
             idx = sortperm(marker, rev = true)
+        elseif plotOrder == :propabs
+            idx = sortperm(abs.(marker))
         else
-            error("plotOrder only supports for :normal, :s2l, or :l2s.")
+            error("plotOrder only supports for :normal, :s2l, :l2s, or :propabs.")
         end
         X = X[idx, :]
         marker = marker[idx]
         if length(ms) > 1
             ms = ms[idx]
+        end
+        # if plotOrder is :propabs, set ms to be a vector prop to
+        # abs.(marker) automatically
+        if plotOrder == :propabs
+            markerabsmax = maximum(abs.(marker))
+            ms = 10 .* log.(1 .+ abs.(marker)) ./ (log(1 + markerabsmax) + 10^3 * eps())
         end
     end
     if dim == 2
@@ -176,13 +186,21 @@ function scatter_gplot!(X; marker = nothing, ms = 4, shape = :none, mswidth = 0,
             idx = sortperm(marker)
         elseif plotOrder == :l2s
             idx = sortperm(marker, rev = true)
+        elseif plotOrder == :propabs
+            idx = sortperm(abs.(marker))
         else
-            error("plotOrder only supports for :normal, :s2l, or :l2s.")
+            error("plotOrder only supports for :normal, :s2l, :l2s, or :propabs.")
         end
         X = X[idx, :]
         marker = marker[idx]
         if length(ms) > 1
             ms = ms[idx]
+        end
+        # if plotOrder is :propabs, set ms to be a vector prop to
+        # abs.(marker) automatically
+        if plotOrder == :propabs
+            markerabsmax = maximum(abs.(marker))
+            ms = 10 .* log.(1 .+ abs.(marker)) ./ (log(1 + markerabsmax) + 10^3 * eps())
         end
     end
     if dim == 2


### PR DESCRIPTION
1. implemented a straightforward version of the `stem` function in `src/helpers.jl` and use it to finish the 1D case of `GraphSig_Plot()`.
2. add `plotOrder = :propabs` option in `scatter_gplot()`, so the marker sizes are automatically proportional to the absolute value of the data points, i.e., |f|. In particular, the conversion is done by the following formula
<a href="https://www.codecogs.com/eqnedit.php?latex=\mathrm{markersize}&space;=&space;10&space;\cdot&space;\dfrac{\log(1&space;&plus;&space;|f|)}{\log(1&space;&plus;&space;\max(|f|))}" target="_blank"><img src="https://latex.codecogs.com/gif.latex?\mathrm{markersize}&space;=&space;10&space;\cdot&space;\dfrac{\log(1&space;&plus;&space;|f|)}{\log(1&space;&plus;&space;\max(|f|))}" title="\mathrm{markersize} = 10 \cdot \dfrac{\log(1 + |f|)}{\log(1 + \max(|f|))}" /></a>